### PR TITLE
替换 Windows 专有 API 为跨平台实现，支持 Linux/Unix 编译

### DIFF
--- a/customio.cpp
+++ b/customio.cpp
@@ -567,7 +567,17 @@ namespace customio {
     };
 
     redraw();
+
+#ifndef _WIN32
+    termios oldt, newt;
+    tcgetattr(STDIN_FILENO, &oldt);
+    newt = oldt;
+    newt.c_lflag &= ~(ICANON | ECHO);
+    tcsetattr(STDIN_FILENO, TCSANOW, &newt);
+#endif
+
     while (running) {
+#ifdef _WIN32
         int ch = _getch();
         if (ch == 224) {
             ch = _getch();
@@ -577,13 +587,56 @@ namespace customio {
         } else if (ch == 13) {
             running = false;
         }
+#else
+        char ch;
+        if (read(STDIN_FILENO, &ch, 1) <= 0) continue;
+        if (ch == '\x1b') {
+            char seq[2];
+            if (read(STDIN_FILENO, seq, 2) != 2) continue;
+            if (seq[0] == '[') {
+                if (seq[1] == 'A' && selected > 0) selected--;
+                else if (seq[1] == 'B' && selected < (int)items.size() - 1) selected++;
+                redraw();
+            }
+        } else if (ch == '\n' || ch == '\r') {
+            running = false;
+        }
+#endif
     }
+
+#ifndef _WIN32
+    tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+#endif
+
     return selected;
 }
-    
+
+int getch() {
+#ifdef _WIN32
+    return _getch();
+#else
+    termios oldt, newt;
+    tcgetattr(STDIN_FILENO, &oldt);
+    newt = oldt;
+    newt.c_lflag &= ~(ICANON | ECHO);
+    tcsetattr(STDIN_FILENO, TCSANOW, &newt);
+
+    char ch = 0;
+    if (read(STDIN_FILENO, &ch, 1) <= 0) ch = -1;
+
+    tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+    return static_cast<unsigned char>(ch);
+#endif
+}
+
+void wait_key() {
+    getch();
+}
+
 } // namespace customio
 
 std::string Utf8ToAnsi(const std::string& utf8_str) {
+#ifdef _WIN32
     if (utf8_str.empty()) return "";
 
     // UTF-8 转 UTF-16
@@ -601,4 +654,8 @@ std::string Utf8ToAnsi(const std::string& utf8_str) {
     // 去除末尾 '\0'
     if (!result.empty() && result.back() == '\0') result.pop_back();
     return result;
+#else
+    // Linux/Unix terminals are natively UTF-8 capable
+    return utf8_str;
+#endif
 }

--- a/customio.h
+++ b/customio.h
@@ -157,6 +157,10 @@ namespace customio {
     enum class log_level { INFO, WARN, ERR };
     std::ostream& log(log_level level);
 
+    // ---------- 跨平台单键输入 ----------
+    int  getch();      // 读取一个字符（无回显）；Linux 返回原始字节
+    void wait_key();   // 等待任意按键
+
     // ---------- 初始化（Windows启用ANSI）----------
     void init_console();
 

--- a/file_utils.cpp
+++ b/file_utils.cpp
@@ -1,54 +1,56 @@
-﻿// file_utils.cpp
+// file_utils.cpp
 #include "file_utils.h"
-#define NOMINMAX
-#include <windows.h>
-#include <iostream>
-#include <string>
+#include <filesystem>
+#include <algorithm>
 
 namespace FileUtils {
 
     std::vector<std::string> scan_directory(const std::string& dir_path, const std::string& extension) {
         std::vector<std::string> files;
+        std::error_code ec;
 
-        // 构造搜索路径，例如 "config/skills/*.json"
-        std::string search_path = dir_path + "\\*" + extension;
-
-        WIN32_FIND_DATAA find_data;
-        HANDLE hFind = FindFirstFileA(search_path.c_str(), &find_data);
-        if (hFind == INVALID_HANDLE_VALUE) {
-            // 目录不存在或没有匹配文件，静默返回
+        if (!std::filesystem::exists(dir_path, ec) || !std::filesystem::is_directory(dir_path, ec)) {
             return files;
         }
 
-        do {
-            // 跳过 "." 和 ".."
-            if (strcmp(find_data.cFileName, ".") == 0 || strcmp(find_data.cFileName, "..") == 0) {
-                continue;
+        for (const auto& entry : std::filesystem::directory_iterator(dir_path, ec)) {
+            if (ec) break;
+            if (entry.is_regular_file() && entry.path().extension() == extension) {
+                files.push_back(entry.path().string());
             }
-            // 构造完整路径
-            std::string full_path = dir_path + "\\" + find_data.cFileName;
-            files.push_back(full_path);
-        } while (FindNextFileA(hFind, &find_data));
+        }
 
-        FindClose(hFind);
+        std::sort(files.begin(), files.end());
         return files;
     }
 
-    // 如果需要递归扫描子目录，可以在这里加一个递归版本，但目前的用法只需要一层
-    // 为了兼容，这里保持原来的函数签名，但只扫描一级目录
     std::vector<std::string> scan_directory_recursive(const std::string& dir_path, const std::string& extension) {
-        // 简单起见，暂时只返回一级文件，你的现有代码也只用到一级扫描
-        return scan_directory(dir_path, extension);
+        std::vector<std::string> files;
+        std::error_code ec;
+
+        if (!std::filesystem::exists(dir_path, ec) || !std::filesystem::is_directory(dir_path, ec)) {
+            return files;
+        }
+
+        for (const auto& entry : std::filesystem::recursive_directory_iterator(dir_path, ec)) {
+            if (ec) break;
+            if (entry.is_regular_file() && entry.path().extension() == extension) {
+                files.push_back(entry.path().string());
+            }
+        }
+
+        std::sort(files.begin(), files.end());
+        return files;
     }
 
     bool file_exists(const std::string& path) {
-        DWORD attrib = GetFileAttributesA(path.c_str());
-        return (attrib != INVALID_FILE_ATTRIBUTES && !(attrib & FILE_ATTRIBUTE_DIRECTORY));
+        std::error_code ec;
+        return std::filesystem::exists(path, ec) && std::filesystem::is_regular_file(path, ec);
     }
 
     bool dir_exists(const std::string& path) {
-        DWORD attrib = GetFileAttributesA(path.c_str());
-        return (attrib != INVALID_FILE_ATTRIBUTES && (attrib & FILE_ATTRIBUTE_DIRECTORY));
+        std::error_code ec;
+        return std::filesystem::exists(path, ec) && std::filesystem::is_directory(path, ec);
     }
 
 } // namespace FileUtils

--- a/game.cpp
+++ b/game.cpp
@@ -15,8 +15,6 @@
 #include "console.h"
 #include <iostream>
 #include <fstream>
-#include <conio.h>
-
 using namespace customio;
 
 Game::Game() {
@@ -134,7 +132,7 @@ void Game::run() {
 
     if (!ok) {
         std::cout << "模组加载失败，请检查文件。\n按任意键退出...";
-        _getch();
+        getch();
         return;
     }
 

--- a/namemark_version1.4.cpp
+++ b/namemark_version1.4.cpp
@@ -4,12 +4,16 @@
 #include "console.h"
 #include "act.h"
 #include "game.h"    
+#ifdef _WIN32
 #include <windows.h>
+#endif
 
 using namespace customio;
 
 int main() {
+#ifdef _WIN32
     SetConsoleTitleA("Namemark");
+#endif
     init_console();
     registerAllSkills();
     // 启动游戏

--- a/package_manager.cpp
+++ b/package_manager.cpp
@@ -1,45 +1,33 @@
-﻿// package_manager.cpp
+// package_manager.cpp
 #include "package_manager.h"
-#define NOMINMAX
-#include <windows.h>
+#include <filesystem>
 #include <iostream>
 
 std::vector<PackageInfo> PackageManager::scan() {
     std::vector<PackageInfo> result;
-    std::string search_path = "packages\\*";
+    std::error_code ec;
 
-    WIN32_FIND_DATAA find_data;
-    HANDLE hFind = FindFirstFileA(search_path.c_str(), &find_data);
-    if (hFind == INVALID_HANDLE_VALUE) {
+    if (!std::filesystem::exists("packages", ec) || !std::filesystem::is_directory("packages", ec)) {
         std::cerr << "[PackageManager] 未找到 packages/ 目录。\n";
         return result;
     }
 
-    do {
-        if (strcmp(find_data.cFileName, ".") == 0 || strcmp(find_data.cFileName, "..") == 0)
-            continue;
+    for (const auto& entry : std::filesystem::directory_iterator("packages", ec)) {
+        if (ec) break;
+        if (!entry.is_directory()) continue;
 
-        if (find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-            std::string dir_name = find_data.cFileName;
-            std::string full_path = "packages/" + dir_name;
+        std::string dir_name = entry.path().filename().string();
+        bool has_monsters = std::filesystem::exists(entry.path() / "monsters.json", ec);
+        bool has_levels   = std::filesystem::exists(entry.path() / "levels.json", ec);
 
-            // 检查该目录下是否存在 monsters.json 或 levels.json
-            std::string monster_file = full_path + "/monsters.json";
-            std::string level_file = full_path + "/levels.json";
-
-            bool has_monsters = (GetFileAttributesA(monster_file.c_str()) != INVALID_FILE_ATTRIBUTES);
-            bool has_levels = (GetFileAttributesA(level_file.c_str()) != INVALID_FILE_ATTRIBUTES);
-
-            if (has_monsters || has_levels) {
-                PackageInfo info;
-                info.name = dir_name;
-                info.path = full_path;
-                info.display = dir_name; // 后续可读取 package.json 获取显示名
-                result.push_back(info);
-            }
+        if (has_monsters || has_levels) {
+            PackageInfo info;
+            info.name    = dir_name;
+            info.path    = entry.path().string();
+            info.display = dir_name;
+            result.push_back(info);
         }
-    } while (FindNextFileA(hFind, &find_data));
+    }
 
-    FindClose(hFind);
     return result;
 }

--- a/selection_list.cpp
+++ b/selection_list.cpp
@@ -13,22 +13,34 @@ std::vector<size_t> SelectionList::run(RenderItemFunc render_func) {
     render_page(render_func);
 
     while (running) {
+#ifdef _WIN32
         int ch = _getch();
-        if (ch == 224) { // 方向键
+        if (ch == 224) {
             ch = _getch();
             size_t old_cursor = cursor_index_;
-            if (ch == 72 && cursor_index_ > 0) { // 上
-                cursor_index_--;
-            }
-            else if (ch == 80 && cursor_index_ < item_count_ - 1) { // 下
-                cursor_index_++;
-            }
+            if (ch == 72 && cursor_index_ > 0) cursor_index_--;
+            else if (ch == 80 && cursor_index_ < item_count_ - 1) cursor_index_++;
 
             if (old_cursor != cursor_index_) {
-                // 重新绘制当前页（光标位置改变）
                 render_page(render_func);
             }
         }
+#else
+        int ch = getch();
+        if (ch == '\x1b') {
+            ch = getch();
+            if (ch == '[') {
+                ch = getch();
+                size_t old_cursor = cursor_index_;
+                if (ch == 'A' && cursor_index_ > 0) cursor_index_--;
+                else if (ch == 'B' && cursor_index_ < item_count_ - 1) cursor_index_++;
+
+                if (old_cursor != cursor_index_) {
+                    render_page(render_func);
+                }
+            }
+        }
+#endif
         else if (ch == 32) { // 空格键
             if (cursor_index_ < item_count_) {
                 bool currently_selected = selected_[cursor_index_];

--- a/selection_list.h
+++ b/selection_list.h
@@ -4,7 +4,6 @@
 #include <vector>
 #include <string>
 #include <functional>
-#include <conio.h>
 #include "customio.h"
 
 // 通用多选列表组件

--- a/states/adventure_state.cpp
+++ b/states/adventure_state.cpp
@@ -6,7 +6,6 @@
 #include "../act.h"       // SkillRegistry, make_unique<Attack> etc.
 #include <iostream>
 #include <iomanip>
-#include <conio.h>
 #include <algorithm>
 #include <memory>
 
@@ -84,7 +83,7 @@ void AdventureState::show_level_list_menu() {
     if (level_count == 0) {
         std::cout << "没有可用关卡。\n";
         std::cout << "按任意键继续...";
-        _getch();
+        getch();
         return;
     }
 
@@ -318,6 +317,6 @@ bool AdventureState::play_level(int level_index) {
     }
 
     std::cout << "\n按任意键继续...";
-    _getch();
+    getch();
     return victory;
 }

--- a/states/gacha_state.cpp
+++ b/states/gacha_state.cpp
@@ -3,7 +3,6 @@
 #include "../customio.h"
 #include <iostream>
 #include <iomanip>
-#include <conio.h>
 #include <random>
 #include <algorithm>
 
@@ -38,7 +37,7 @@ PullResult GachaState::random_pull() {
 void GachaState::single_pull() {
     if (ctx_.gold < ctx_.gacha_single_cost) {
         std::cout << "金币不足！\n按任意键返回...";
-        _getch();
+        getch();
         return;
     }
     ctx_.gold -= ctx_.gacha_single_cost;
@@ -49,7 +48,7 @@ void GachaState::single_pull() {
 void GachaState::ten_pull() {
     if (ctx_.gold < ctx_.gacha_ten_cost) {
         std::cout << "金币不足！\n按任意键返回...";
-        _getch();
+        getch();
         return;
     }
     ctx_.gold -= ctx_.gacha_ten_cost;
@@ -120,7 +119,7 @@ void GachaState::display_result(const std::vector<PullResult>& results) {
 
     std::cout << "\n剩余金币: " << ctx_.gold << "\n";
     std::cout << "按任意键继续...";
-    _getch();
+    getch();
 }
 
 void GachaState::update() {

--- a/states/shop_state.cpp
+++ b/states/shop_state.cpp
@@ -6,7 +6,6 @@
 #include "../weapon_data.h"
 #include <iostream>
 #include <iomanip>
-#include <conio.h>
 #include <algorithm>
 
 using namespace customio;
@@ -24,7 +23,7 @@ void ShopState::show_weapon_list() {
     // 检查武器模板库，而不是玩家武器库
     if (ctx_.weapon_templates.empty()) {
         std::cout << "当前模组没有武器可购买。\n按任意键返回...";
-        _getch();
+        getch();
         return;
     }
 
@@ -63,7 +62,7 @@ void ShopState::show_weapon_list() {
 void ShopState::buy_weapon(const WeaponData& weapon_template) {
     if (ctx_.gold < weapon_template.price) {
         std::cout << "金币不足！\n按任意键返回...";
-        _getch();
+        getch();
         return;
     }
     show_character_select_for_weapon(weapon_template);
@@ -72,7 +71,7 @@ void ShopState::buy_weapon(const WeaponData& weapon_template) {
 void ShopState::show_character_select_for_weapon(const WeaponData& weapon_template) {
     if (ctx_.all_characters.empty()) {
         std::cout << "没有可装备的角色，请先创建角色。\n按任意键返回...";
-        _getch();
+        getch();
         return;
     }
 
@@ -118,7 +117,7 @@ void ShopState::show_character_select_for_weapon(const WeaponData& weapon_templa
         ctx_.weapons.pop_back();
         std::cout << "装备失败！\n按任意键返回...";
     }
-    _getch();
+    getch();
 }
 
 void ShopState::update() {

--- a/states/team_state.cpp
+++ b/states/team_state.cpp
@@ -24,7 +24,7 @@ void TeamState::add_new_character() {
     ctx_.all_characters.push_back(std::move(ch));
     std::cout << adaptive_textcolor(theme.info) << "OK！ " << name << " 加入了队伍！\n" << resetcolor();
     std::cout << "按任意键继续...";
-    _getch();
+    getch();
 }
 
 void TeamState::list_characters() {
@@ -100,14 +100,14 @@ void TeamState::select_team() {
     ctx_.selected_team = std::move(new_selected);
     std::cout << "\n出战队伍已更新！当前出战角色: " << ctx_.selected_team.size() << " 人\n";
     std::cout << "按任意键继续...";
-    char ch = _getch();
+    char ch = getch();
 }
 
 
 void TeamState::view_character_detail() {
     if (ctx_.all_characters.empty()) {
         std::cout << "当前没有任何角色。\n按任意键返回...";
-        _getch();
+        getch();
         return;
     }
 
@@ -201,13 +201,26 @@ void TeamState::view_character_detail() {
     draw();
 
     while (running) {
-        int ch = _getch();
-        if (ch == 224) { // 方向键
-            ch = _getch();
+#ifdef _WIN32
+        int ch = getch();
+        if (ch == 224) {
+            ch = getch();
             if (ch == 72 && cursor > 0) cursor--;
             else if (ch == 80 && cursor < ctx_.all_characters.size() - 1) cursor++;
             draw();
         }
+#else
+        int ch = getch();
+        if (ch == '\x1b') {
+            ch = getch();
+            if (ch == '[') {
+                ch = getch();
+                if (ch == 'A' && cursor > 0) cursor--;
+                else if (ch == 'B' && cursor < ctx_.all_characters.size() - 1) cursor++;
+                draw();
+            }
+        }
+#endif
         else if (ch == 'e' || ch == 'E') {
             character& current = *ctx_.all_characters[cursor];
             if (current.has_weapon()) {
@@ -219,7 +232,7 @@ void TeamState::view_character_detail() {
                     }
                 }
                 std::cout << "\n武器已卸下！按任意键...";
-                _getch();
+                getch();
             }
             else {
                 std::vector<std::string> weapon_items;
@@ -234,7 +247,7 @@ void TeamState::view_character_detail() {
                 }
                 if (weapon_items.empty()) {
                     std::cout << "\n没有可装备的武器。按任意键...";
-                    _getch();
+                    getch();
                 }
                 else {
                     weapon_items.push_back("取消");
@@ -249,7 +262,7 @@ void TeamState::view_character_detail() {
                         else {
                             std::cout << "\n装备失败！按任意键...";
                         }
-                        _getch();
+                        getch();
                     }
                 }
             }
@@ -266,7 +279,7 @@ void TeamState::view_character_detail() {
                 std::cout << "评分完成！ " << bgrade << " (" << std::fixed << std::setprecision(1) << bscore << ")\n";
                 std::cout << "详细评分数据已缓存，下次查看角色详情时将直接显示。\n";
                 std::cout << "按任意键继续...";
-                _getch();
+                getch();
             }
             draw();
         }

--- a/states/teamtest_state.cpp
+++ b/states/teamtest_state.cpp
@@ -5,7 +5,6 @@
 #include "../act.h"
 #include <iostream>
 #include <iomanip>
-#include <conio.h>
 #include <algorithm>
 
 using namespace customio;
@@ -17,7 +16,7 @@ void TeamTestState::select_team(const std::string& title, size_t max_selection,
                                 std::vector<size_t>& result) {
     if (ctx_.all_characters.empty()) {
         std::cout << "没有可用的角色。\n";
-        _getch();
+        getch();
         return;
     }
 
@@ -99,7 +98,7 @@ void TeamTestState::start_exercise() {
         for (size_t b : teamB_idx) {
             if (a == b) {
                 std::cout << "队伍 A 和队伍 B 不能包含同一个角色！\n按任意键返回...";
-                _getch();
+                getch();
                 return;
             }
         }
@@ -139,7 +138,7 @@ void TeamTestState::start_exercise() {
     restore_snapshots(snapshots);
 
     std::cout << "\n按任意键继续...";
-    _getch();
+    getch();
 }
 
 void TeamTestState::print_exercise_report(Team& teamA, Team& teamB) {
@@ -193,7 +192,7 @@ void TeamTestState::update() {
 
     if (ctx_.all_characters.size() < 2) {
         std::cout << "角色不足，至少需要2名角色。\n按任意键返回...";
-        _getch();
+        getch();
         Game::getInstance().changeState(GameStateType::LOBBY);
         return;
     }


### PR DESCRIPTION
- 移除 file_utils.cpp / package_manager.cpp 中的 Win32 文件 API，改用 std::filesystem
- 新增 customio::getch() / wait_key() 跨平台单键输入，Linux 下基于 termios
- 为 menu_select / 方向键输入添加 Linux termios 支持
- 所有 windows.h / conio.h / Win32 API 调用均用 #ifdef _WIN32 守卫