### PR TITLE
重写 customio23.h/cpp 为 C++17，移除 C++23 依赖

### DIFF
--- a/customio23.cpp
+++ b/customio23.cpp
@@ -1,6 +1,7 @@
 ﻿#include "customio23.h"
 #include <algorithm>
 #include <cctype>
+#include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -25,7 +26,7 @@ namespace customio23 {
     const theme& get_theme() { return current_theme; }
 
     void apply_theme() {
-        std::print("{}{}", ansi_bg(current_theme.background), ansi_fg(adaptive_fg(current_theme.text)));
+        cprint("{}{}", ansi_bg(current_theme.background), ansi_fg(adaptive_fg(current_theme.text)));
         clear_screen();
     }
 
@@ -78,23 +79,23 @@ namespace customio23 {
     }
 
     std::string input(std::string_view prompt) {
-        std::print("{}", prompt);
+        cprint("{}", prompt);
         std::string line;
         std::getline(std::cin, line);
         return line;
     }
 
     std::string prompt(std::string_view prompt_text, color c) {
-        std::print("{}{}{}", ansi_bg(current_theme.background),
+        cprint("{}{}{}", ansi_bg(current_theme.background),
             ansi_fg(adaptive_fg(c)), prompt_text);
-        std::print("{}", ansi_fg(adaptive_fg(current_theme.text)));
+        cprint("{}", ansi_fg(adaptive_fg(current_theme.text)));
         std::string line;
         std::getline(std::cin, line);
         return line;
     }
 
     bool confirm(std::string_view prompt, bool default_yes) {
-        std::print("{} [{}]: ", prompt, default_yes ? "Y/n" : "y/N");
+        cprint("{} [{}]: ", prompt, default_yes ? "Y/n" : "y/N");
         std::string ans;
         std::getline(std::cin, ans);
         auto start = ans.find_first_not_of(" \t");
@@ -106,27 +107,27 @@ namespace customio23 {
     // ===== get_password =====
 #ifdef _WIN32
     std::string get_password(std::string_view prompt, char mask) {
-        std::print("{}", prompt);
+        cprint("{}", prompt);
         std::string pwd;
         while (true) {
             int ch = _getch();
-            if (ch == '\r' || ch == '\n') { std::print("\n"); break; }
+            if (ch == '\r' || ch == '\n') { cprint("\n"); break; }
             if (ch == '\b' || ch == 127) {
                 if (!pwd.empty()) {
                     pwd.pop_back();
-                    std::print("\b \b");
+                    cprint("\b \b");
                 }
             }
             else {
                 pwd.push_back((char)ch);
-                std::print("{}", mask);
+                cprint("{}", mask);
             }
         }
         return pwd;
     }
 #else
     std::string get_password(std::string_view prompt, char mask) {
-        std::print("{}", prompt);
+        cprint("{}", prompt);
         std::string pwd;
 
         termios oldt, newt;
@@ -139,18 +140,18 @@ namespace customio23 {
         while (true) {
             read(STDIN_FILENO, &ch, 1);
             if (ch == '\n' || ch == '\r') {
-                std::print("\n");
+                cprint("\n");
                 break;
             }
             else if (ch == 127 || ch == '\b') {
                 if (!pwd.empty()) {
                     pwd.pop_back();
-                    std::print("\b \b");
+                    cprint("\b \b");
                 }
             }
             else {
                 pwd.push_back(ch);
-                std::print("{}", mask);
+                cprint("{}", mask);
             }
         }
 
@@ -184,16 +185,16 @@ namespace customio23 {
 
         auto print_row = [&](const std::vector<std::string>& row, bool is_header) {
             for (size_t i = 0; i < row.size(); ++i) {
-                std::print(" {:<{}} ", row[i], widths[i]);
-                if (i < row.size() - 1) std::print("|");
+                std::cout << " " << std::left << std::setw(widths[i]) << row[i] << " ";
+                if (i < row.size() - 1) std::cout << "|";
             }
-            std::print("\n");
+            std::cout << "\n";
             if (is_header) {
                 for (size_t i = 0; i < row.size(); ++i) {
-                    std::print("{:-<{}}", "", widths[i] + 2);
-                    if (i < row.size() - 1) std::print("+");
+                    std::cout << std::string(widths[i] + 2, '-');
+                    if (i < row.size() - 1) std::cout << "+";
                 }
-                std::print("\n");
+                std::cout << "\n";
             }
             };
 
@@ -258,7 +259,7 @@ namespace customio23 {
         tcsetattr(STDIN_FILENO, TCSANOW, &newt);
 
         auto draw = [&]() {
-            std::print("\033[2J\033[1;1H");
+            cprint("\033[2J\033[1;1H");
             if (!title.empty()) {
                 cprintln("{}", styled(title, current_theme.title, text_style::bold));
             }
@@ -305,22 +306,36 @@ namespace customio23 {
     void progress_bar::update(int progress) {
         progress = std::clamp(progress, 0, total_);
         int pos = progress * width_ / total_;
-        std::print("\r[");
+        cprint("\r[");
         for (int i = 0; i < width_; ++i) {
-            if (i < pos) std::print("{}", fill_);
-            else if (i == pos && progress < total_) std::print(">");
-            else std::print("{}", empty_);
+            if (i < pos) cprint("{}", fill_);
+            else if (i == pos && progress < total_) cprint(">");
+            else cprint("{}", empty_);
         }
-        std::print("]");
+        cprint("]");
         if (show_percent_) {
             int pct = progress * 100 / total_;
-            std::print(" {}%", pct);
+            cprint(" {}%", pct);
         }
     }
 
     void progress_bar::finish() {
         update(total_);
-        std::print("\n");
+        cprint("\n");
+    }
+
+    // ===== operator<< for styled_text =====
+    std::ostream& operator<<(std::ostream& os, const styled_text& st) {
+        if (has_style(st.style, text_style::bold))      os << "\033[1m";
+        if (has_style(st.style, text_style::italic))    os << "\033[3m";
+        if (has_style(st.style, text_style::underline)) os << "\033[4m";
+
+        color use_fg = adaptive_fg(st.fg);
+        os << ansi_fg(use_fg);
+        os << st.text;
+        os << "\033[22m\033[23m\033[24m\033[39m";
+        os << ansi_fg(adaptive_fg(current_theme.text));
+        return os;
     }
 
     // ===== Spinner =====
@@ -329,22 +344,22 @@ namespace customio23 {
 
     void spinner::start() {
         if (!thread_.joinable()) {
-            thread_ = std::jthread([this](std::stop_token stoken) {
+            running_ = true;
+            thread_ = std::thread([this]() {
                 const char frames[] = { '|', '/', '-', '\\' };
                 int i = 0;
-                while (!stoken.stop_requested()) {
-                    std::print("\r{} {}", message_, frames[i % 4]);
+                while (running_) {
+                    std::cout << "\r" << message_ << " " << frames[i % 4] << std::flush;
                     std::this_thread::sleep_for(std::chrono::milliseconds(100));
                     ++i;
                 }
-                // 清除行（安全填充空格）
-                std::print("\r{: <{}}\r", ' ', message_.size() + 4);
-                });
+                std::cout << "\r" << std::string(message_.size() + 4, ' ') << "\r" << std::flush;
+            });
         }
     }
 
     void spinner::stop() {
-        thread_.request_stop();
+        running_ = false;
         if (thread_.joinable()) thread_.join();
     }
 

--- a/customio23.h
+++ b/customio23.h
@@ -1,9 +1,9 @@
-﻿#ifndef CUSTOMIO23_H
+#ifndef CUSTOMIO23_H
 #define CUSTOMIO23_H
 
+#include <atomic>
 #include <chrono>
 #include <cstdint>
-#include <format>
 #include <functional>
 #include <iostream>
 #include <random>
@@ -11,16 +11,15 @@
 #include <string_view>
 #include <thread>
 #include <vector>
-#include <print>
 
 namespace customio23 {
 
-    // ---- 颜色枚举 ----
+    // ---- 颜色 ----
     enum class color : uint8_t {
         black, red, green, yellow, blue, magenta, cyan, white, reset, orange
     };
 
-    // ---- 主题定义 ----
+    // ---- 主题 ----
     struct theme {
         color background;
         color text;
@@ -37,55 +36,53 @@ namespace customio23 {
 
     inline constexpr theme default_theme{
         .background = color::black,
-        .text = color::white,
-        .damage = color::red,
-        .heal = color::green,
-        .attack = color::cyan,
-        .special = color::magenta,
-        .warning = color::yellow,
-        .info = color::blue,
-        .error = color::red,
-        .prompt = color::cyan,
-        .title = color::yellow
+        .text       = color::white,
+        .damage     = color::red,
+        .heal       = color::green,
+        .attack     = color::cyan,
+        .special    = color::magenta,
+        .warning    = color::yellow,
+        .info       = color::blue,
+        .error      = color::red,
+        .prompt     = color::cyan,
+        .title      = color::yellow
     };
 
     inline constexpr theme light_theme{
         .background = color::white,
-        .text = color::black,
-        .damage = color::red,
-        .heal = color::green,
-        .attack = color::blue,
-        .special = color::magenta,
-        .warning = color::yellow,
-        .info = color::blue,
-        .error = color::red,
-        .prompt = color::blue,
-        .title = color::black
+        .text       = color::black,
+        .damage     = color::red,
+        .heal       = color::green,
+        .attack     = color::blue,
+        .special    = color::magenta,
+        .warning    = color::yellow,
+        .info       = color::blue,
+        .error      = color::red,
+        .prompt     = color::blue,
+        .title      = color::black
     };
 
-    // ---- 全局主题管理 ----
     extern theme current_theme;
     extern float g_battle_speed;
 
     void set_theme(const theme& t);
     const theme& get_theme();
     void apply_theme();
-
     color adaptive_fg(color desired);
 
-    // ---- 样式描述 ----
+    // ---- 样式 ----
     enum class text_style : uint8_t {
-        normal = 0,
-        bold = 1 << 0,
-        italic = 1 << 1,
+        normal    = 0,
+        bold      = 1 << 0,
+        italic    = 1 << 1,
         underline = 1 << 2
     };
 
     constexpr text_style operator|(text_style a, text_style b) {
-        return static_cast<text_style>(std::to_underlying(a) | std::to_underlying(b));
+        return static_cast<text_style>(static_cast<uint8_t>(a) | static_cast<uint8_t>(b));
     }
     constexpr bool has_style(text_style s, text_style flag) {
-        return (std::to_underlying(s) & std::to_underlying(flag)) != 0;
+        return (static_cast<uint8_t>(s) & static_cast<uint8_t>(flag)) != 0;
     }
 
     struct styled_text {
@@ -95,12 +92,14 @@ namespace customio23 {
     };
 
     constexpr styled_text styled(std::string_view t,
-        color fg = color::reset,
-        text_style st = text_style::normal) {
+                                  color fg = color::reset,
+                                  text_style st = text_style::normal) {
         return { t, fg, st };
     }
 
-    // ---- ANSI 工具 ----
+    std::ostream& operator<<(std::ostream& os, const styled_text& st);
+
+    // ---- ANSI ----
     inline constexpr std::string_view ansi_fg(color c) {
         using namespace std::string_view_literals;
         switch (c) {
@@ -135,36 +134,56 @@ namespace customio23 {
         }
     }
 
-    inline void clear_screen() { std::print("\033[2J\033[1;1H"); }
-    inline void clear_line() { std::print("\033[2K\r"); }
+    inline void clear_screen() { std::cout << "\033[2J\033[1;1H"; }
+    inline void clear_line()   { std::cout << "\033[2K\r"; }
 
-    // ---- 公共输出（使用 cprint/cprintln 避免与 std::print 重名） ----
-    template <typename... Args>
-    void cprint(std::format_string<Args...> fmt, Args&&... args) {
-        std::print(fmt, std::forward<Args>(args)...);
+    // ---- cprint / cprintln（C++17 兼容，{} 替换实现）----
+    namespace detail {
+        template<typename T>
+        void write_one(std::ostream& os, const T& v) { os << v; }
+
+        inline void write_fmt(std::ostream& os, std::string_view fmt) {
+            os << fmt;  // output remaining literal text
+        }
+
+        template<typename T, typename... Rest>
+        void write_fmt(std::ostream& os, std::string_view fmt, const T& first, Rest&&... rest) {
+            auto pos = fmt.find("{}");
+            if (pos != std::string_view::npos) {
+                os << fmt.substr(0, pos);
+                write_one(os, first);
+                write_fmt(os, fmt.substr(pos + 2), std::forward<Rest>(rest)...);
+            }
+        }
+    } // namespace detail
+
+    template<typename... Args>
+    void cprint(std::string_view fmt, Args&&... args) {
+        detail::write_fmt(std::cout, fmt, std::forward<Args>(args)...);
     }
 
-    template <typename... Args>
-    void cprintln(std::format_string<Args...> fmt, Args&&... args) {
-        std::println(fmt, std::forward<Args>(args)...);
+    template<typename... Args>
+    void cprintln(std::string_view fmt, Args&&... args) {
+        cprint(fmt, std::forward<Args>(args)...);
+        std::cout << '\n';
     }
 
     inline void themed_println(std::string_view text, color fg = color::reset,
-        text_style st = text_style::normal) {
+                                text_style st = text_style::normal) {
         cprintln("{}", styled(text, fg, st));
     }
 
-    std::string prompt(std::string_view prompt_text, color c = color::cyan);
-    void print_table(const std::vector<std::vector<std::string>>& data, bool header = false);
-
-    // ---- 输入函数 ----
+    // ---- 输入 ----
     std::string input(std::string_view prompt);
     std::string get_password(std::string_view prompt, char mask = '*');
     bool confirm(std::string_view prompt, bool default_yes = true);
     int menu_select(const std::vector<std::string>& items, std::string_view title = "");
 
-    // ---- 随机与时间 ----
-    void game_sleep(int milliseconds);
+    // ---- 输出 ----
+    void print_table(const std::vector<std::vector<std::string>>& data, bool header = false);
+
+    // ---- 时间 / 随机 ----
+    void game_sleep(int ms);
     std::mt19937& rng();
     bool chance(int percent);
     bool chance(double probability);
@@ -176,15 +195,17 @@ namespace customio23 {
         bool show_percent_;
     public:
         progress_bar(int total, int width = 50, char fill = '=', char empty = ' ',
-            bool show_percent = true);
+                     bool show_percent = true);
         void update(int progress);
         void finish();
     };
 
-    // ---- 旋转指示器 ----
+    // ---- 旋转器（C++17：std::thread + atomic）----
     class spinner {
-        std::jthread thread_;
+        std::thread thread_;
+        std::atomic<bool> running_{false};
         std::string message_;
+        void run();
     public:
         explicit spinner(std::string_view message = "");
         ~spinner();
@@ -198,27 +219,4 @@ namespace customio23 {
 
 } // namespace customio23
 
-// ---- std::formatter 特化 styled_text ----
-template <>
-struct std::formatter<customio23::styled_text> {
-    constexpr auto parse(std::format_parse_context& ctx) {
-        return ctx.begin();
-    }
-
-    auto format(const customio23::styled_text& st, std::format_context& ctx) const {
-        using namespace customio23;
-        auto out = ctx.out();
-        if (has_style(st.style, text_style::bold))      out = std::format_to(out, "\033[1m");
-        if (has_style(st.style, text_style::italic))    out = std::format_to(out, "\033[3m");
-        if (has_style(st.style, text_style::underline)) out = std::format_to(out, "\033[4m");
-
-        color use_fg = adaptive_fg(st.fg);
-        out = std::format_to(out, "{}", ansi_fg(use_fg));
-        out = std::format_to(out, "{}", st.text);
-        out = std::format_to(out, "\033[22m\033[23m\033[24m\033[39m");
-        out = std::format_to(out, "{}", ansi_fg(adaptive_fg(current_theme.text)));
-        return out;
-    }
-};
-
-#endif // CUSTOMIO23_H
+#endif


### PR DESCRIPTION
- std::print / std::println → 自实现 cprint / cprintln（{} 替换）
- std::to_underlying → static_cast<uint8_t>
- std::jthread → std::thread + std::atomic<bool>
- std::formatter → operator<< 重载
- 复杂格式字符串（{:<{}}, {:-<{}}）→ std::cout + iomanip / std::string